### PR TITLE
Adds cacheing strategy, pulls out stack logic into data structure

### DIFF
--- a/addon/components/history-outlet/component.js
+++ b/addon/components/history-outlet/component.js
@@ -52,17 +52,16 @@ export default Component.extend({
   _isTransitioning: false,
 
   currentRouteName: '',
-  activeRouteName: computed.alias('history.currentRouteName'),
 
-  canGoBack: computed('history.stack.lastObject', function() {
-    let last = this.get('history.stack.lastObject');
+  canGoBack: computed('history.previous', function() {
+    let last = this.get('history.previous');
     let routeName = this.get('currentRouteName');
 
     return !!last && last.routeName.indexOf(routeName) === 0;
   }),
 
-  canGoForward: computed('history.seen.lastObject', function() {
-    let next = this.get('history.seen.lastObject');
+  canGoForward: computed('history.next', function() {
+    let next = this.get('history.next');
     let routeName = this.get('currentRouteName');
 
     return !!next && next.routeName.indexOf(routeName) === 0;
@@ -117,8 +116,8 @@ export default Component.extend({
         low: low.fps
       });
 
-      this._fpsMeter()
-    })
+      this._fpsMeter();
+    });
   },
 
 
@@ -244,18 +243,12 @@ export default Component.extend({
       });
   },
 
-  _finishTransition(nextState) {
-    let previous = this.domFor(nextState.previous, 'previous');
-    let next = this.domFor(nextState.next, 'next');
-
-    this._left.innerHTML = '';
-    this._right.innerHTML = '';
-
+  _finishTransition({ previous, next }) {
     if (previous) {
-      appendRange(this._left, previous.firstChild, previous.lastChild);
+      this.get('history').restoreFromCache(previous.url, this._left);
     }
     if (next) {
-      appendRange(this._right, next.firstChild, next.lastChild);
+      this.get('history').restoreFromCache(next.url, this._right);
     }
   },
 
@@ -299,10 +292,14 @@ export default Component.extend({
     this._main = this.element.children[1];
     this._right = this.element.children[2];
     this._outlet = this.element.children[3];
+
+    this.get('history').activate(this, this._outlet, this.get('name'));
   },
 
   willDestroyElement() {
     this._super();
+    this.get('history').deactivate();
+
     this._left = undefined;
     this._main = undefined;
     this._right = undefined;

--- a/addon/models/history-stack.js
+++ b/addon/models/history-stack.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+
+const {
+  A,
+  computed
+} = Ember;
+
+export default Ember.Object.extend({
+  stack: undefined,
+  seen: undefined,
+
+  previous: computed.alias('stack.lastObject'),
+  next: computed.alias('seen.lastObject'),
+  current: undefined,
+
+  init() {
+    this.set('stack', new A([]));
+    this.set('seen', new A([]));
+  },
+
+  forward() {
+    let next = this.get('seen').popObject();
+
+    if (next) {
+      let current = this.get('current');
+
+      this.get('stack').pushObject(current);
+      this.set('current', next);
+    }
+  },
+
+  back() {
+    let prev = this.get('stack').popObject();
+
+    if (prev) {
+      let current = this.get('current');
+
+      this.get('seen').pushObject(current);
+      this.set('current', prev);
+    }
+  },
+
+  push(item) {
+    let previous = this.get('current');
+
+    this.get('stack').pushObject(previous);
+    this.set('current', item);
+
+    this.get('seen').clear();
+  }
+});

--- a/addon/services/history-cache.js
+++ b/addon/services/history-cache.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+import cloneRange from '../utils/dom/clone-range';
+import appendRange from '../utils/dom/append-range';
+
+const {
+  Service,
+  } = Ember;
+
+export default Service.extend({
+  init() {
+    this.set('cache', new Map());
+  },
+
+  update(url, outletName, element) {
+    const cache = this.get('cache');
+    const key = `${url}-${outletName}`;
+    const dom = cloneRange('outlet-segment', element.firstChild, element.lastChild);
+
+    let stale = cache.get(key);
+
+    if (stale) {
+      stale.dom = null;
+    }
+
+    this.get('cache').set(key, { url, outletName, dom });
+  },
+
+  restore(url, outletName, element) {
+    element.innerHTML = '';
+
+    const cache = this.get('cache');
+    const key = `${url}-${outletName}`;
+
+    const cached = cache.get(key);
+
+
+    if (cached && cached.dom) {
+      appendRange(element, cached.dom.firstChild, cached.dom.lastChild);
+    }
+  }
+});

--- a/app/services/history-cache.js
+++ b/app/services/history-cache.js
@@ -1,0 +1,1 @@
+export { default } from 'history/services/history-cache';

--- a/tests/dummy/app/routes/application/template.hbs
+++ b/tests/dummy/app/routes/application/template.hbs
@@ -1,6 +1,3 @@
 <screen>
-  {{!--
-  {{history-outlet currentRouteName=currentRouteName}}
-  --}}
   {{outlet}}
 </screen>


### PR DESCRIPTION
Adds a cacheing strategy via the `history-cache` service. In the process the `history-service` was refactored pretty significantly by pulling the stack/seen logic out into a separate data structure, adding support for multiple named `history-outlet`s, and adding an activation process to give the service more context for taking and restoring snapshots.

Major Changes:
- `history-outlets` now activate when they enter the DOM and deactivate when they exit. This gives us three things: We can give context to the cache-strategy so it only caches the minimum, we can prevent cacheing when there are no `history-outlets` on the current route, and we can support multiple `history-outlets` rendering on different pages. It is still assumed that only a single `history-outlet` will ever be active at once, but my hope is that eventually we will be able to have multiple routing contexts rendered at once, and each will be able to have a history-outlet.
- `HistoryStack` was introduced, and contains all of the stack logic. This also enables multiple `history-outlet`s, as each one needs its own stack.
- `history-cache` was introduced, using a significantly simplified DOM cacheing strategy. Since we have the element of the active outlet, when we route we can clone only the contents of that element, making the logic much simpler. 
